### PR TITLE
Update tag naming scheme for automation

### DIFF
--- a/.github/workflows/build-stable-vaniglia.yml
+++ b/.github/workflows/build-stable-vaniglia.yml
@@ -66,7 +66,7 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           draft: false
           prerelease: false
-          automatic_release_tag: "${{ steps.vars.outputs.release_version }}"
+          automatic_release_tag: "vaniglia-${{ steps.vars.outputs.release_version }}"
           title: "Vaniglia ${{ steps.vars.outputs.release_version }}"
           files: "/home/runner/work/wine/wine/vaniglia-${{ steps.vars.outputs.release_version }}-x86_64.tar.gz"
           


### PR DESCRIPTION
Include the `vaniglia` prefix (just like `caffe` and `soda`), in the tag name for future release, it makes it easier to automate pulling update.