### PR TITLE
Update Caffe and Soda workflows

### DIFF
--- a/.github/workflows/build-caffe.yml
+++ b/.github/workflows/build-caffe.yml
@@ -1,0 +1,56 @@
+name: build-caffe
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+env:
+  WINE_VERSION: 8.18
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:        
+      - uses: actions/checkout@v2
+      
+      - name: remove conflicting dependencies
+        working-directory: /home/runner/work/
+        run: sudo apt purge -y ubuntu-advantage-tools
+
+      - name: download environment and install dependencies
+        working-directory: /home/runner/work/
+        run: |
+          curl -o environment.sh https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/environment.sh
+          bash environment.sh
+
+      - name: clone wine-tkg-git repo
+        working-directory: /home/runner/work/
+        run: git clone https://github.com/Frogging-Family/wine-tkg-git.git
+          
+      - name: get/set the caffe recipe
+        working-directory: /home/runner/work/wine-tkg-git/wine-tkg-git/
+        run: |
+          curl https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/wine-tkg.cfg >> customization.cfg
+          sed -i "s/_staging_version=\"\"/_staging_version=\"v$WINE_VERSION\"/g" customization.cfg
+          sed -i "s/_plain_version=\"\"/_plain_version=\"wine-$WINE_VERSION\"/g" customization.cfg
+
+      - name: start build
+        working-directory: /home/runner/work/wine-tkg-git/wine-tkg-git/
+        run: bash non-makepkg-build.sh
+        
+      - name: package
+        working-directory: /home/runner/work/wine-tkg-git/wine-tkg-git/non-makepkg-builds/
+        run: |
+          mv wine-tkg-staging-* caffe-$WINE_VERSION-x86_64
+          tar cJvf caffe-$WINE_VERSION-x86_64.tar.xz caffe-$WINE_VERSION-x86_64
+          mv caffe-$WINE_VERSION-x86_64.tar.xz /tmp/caffe-$WINE_VERSION-x86_64.tar.xz
+        
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          draft: false
+          prerelease: false
+          automatic_release_tag: "caffe-${{ env.WINE_VERSION }}"
+          title: "Caffe ${{ env.WINE_VERSION }}"
+          files: "/tmp/caffe-${{ env.WINE_VERSION }}-x86_64.tar.xz"
+          

--- a/.github/workflows/build-soda.yml
+++ b/.github/workflows/build-soda.yml
@@ -1,0 +1,56 @@
+name: build-soda
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+env:
+  WINE_VERSION: proton_8.0
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:        
+      - uses: actions/checkout@v2
+
+      - name: remove conflicting dependencies
+        working-directory: /home/runner/work/
+        run: sudo apt purge -y ubuntu-advantage-tools
+
+      - name: download environment and install dependencies
+        working-directory: /home/runner/work/
+        run: |
+          curl -o environment-tkg.sh https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/environment-tkg.sh
+          bash environment-tkg.sh
+
+      - name: clone wine-tkg-git repo
+        working-directory: /home/runner/work/
+        run: git clone https://github.com/Frogging-Family/wine-tkg-git.git
+
+      - name: get/set the caffe recipe
+        working-directory: /home/runner/work/wine-tkg-git/wine-tkg-git/
+        run: |
+          curl https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/wine-tkg-valve.cfg > /home/runner/.config/frogminer/wine-tkg.cfg
+          sed -i "s/_plain_version=\"\"/_plain_version=\"$WINE_VERSION\"/g" /home/runner/.config/frogminer/wine-tkg.cfg
+          sed -i "s/_proton_branch=\"\"/_proton_branch=\"$WINE_VERSION\"/g" /home/runner/.config/frogminer/wine-tkg.cfg
+
+      - name: start build
+        working-directory: /home/runner/work/wine-tkg-git/wine-tkg-git/
+        run: bash non-makepkg-build.sh
+      
+      - name: Package
+        working-directory: /home/runner/work/wine-tkg-git/wine-tkg-git/non-makepkg-builds/
+        run: |
+          mv wine-tkg-* soda-$WINE_VERSION-x86_64
+          tar cJvf soda-$WINE_VERSION-x86_64.tar.xz soda-$WINE_VERSION-x86_64
+          mv soda-$WINE_VERSION-x86_64.tar.xz /tmp/soda-$WINE_VERSION-x86_64.tar.xz
+          
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          draft: false
+          prerelease: false
+          automatic_release_tag: "soda-${{ env.WINE_VERSION }}"
+          title: "Soda ${{ env.WINE_VERSION }}"
+          files: "/tmp/soda-${{ env.WINE_VERSION }}-x86_64.tar.xz"


### PR DESCRIPTION
The objective is to homogenize and simplify the various runner workflows as well as bring them up to date. This brings Caffe and Soda in line with Chardonnay and hopefully makes the process of maintaining easier. It is dependent on [this](https://github.com/bottlesdevs/build-tools/pull/7) pull request.

Several open issues can be closed with this. #53, [#3067](https://github.com/bottlesdevs/Bottles/issues/3067), [#216](https://github.com/bottlesdevs/components/issues/216) 

Known Issues:
    - This lacks any stable and unstable labeling and still needs to be addressed.
    - ```fastsync``` was switched off for Caffe as it prevented compilation (missing ```winesync``` header)
    - Soda was compiled against ```proton_8.0``` as ```experimental_8.0``` currently has an upstream [bug](https://github.com/Frogging-Family/wine-tkg-git/issues/1083).
    - I experienced permission issues when creating a new tag during workflows but I assume this is an issues with my fork.

Next Steps:
    - Utilize scripts for programmatic selection of version numbers (as Chardonnay does). They are hard coded as it stands.
 
This pull request needs scrutiny.