### PR TITLE
Let tkg script handle package resolution

### DIFF
--- a/.github/workflows/build-caffe.yml
+++ b/.github/workflows/build-caffe.yml
@@ -13,15 +13,13 @@ jobs:
     steps:        
       - uses: actions/checkout@v2
       
-      - name: remove conflicting dependencies
-        working-directory: /home/runner/work/
-        run: sudo apt purge -y ubuntu-advantage-tools
-
-      - name: download environment and install dependencies
+      - name: setup
         working-directory: /home/runner/work/
         run: |
-          curl -o environment-tkg.sh https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/environment-tkg.sh
-          bash environment-tkg.sh
+          sudo apt purge -y ubuntu-advantage-tools
+          sudo dpkg --add-architecture i386 && sudo apt update
+          sudo apt install aptitude
+          sudo aptitude remove -y '?narrow(?installed,?version(deb.sury.org))'
 
       - name: clone wine-tkg-git repo
         working-directory: /home/runner/work/
@@ -36,7 +34,7 @@ jobs:
 
       - name: start build
         working-directory: /home/runner/work/wine-tkg-git/wine-tkg-git/
-        run: bash non-makepkg-build.sh
+        run: yes|./non-makepkg-build.sh
         
       - name: package
         working-directory: /home/runner/work/wine-tkg-git/wine-tkg-git/non-makepkg-builds/


### PR DESCRIPTION
Instead of using a local environment script to install dependencies. This simplifies the process.