### PR TITLE
Update Soda to 9.0-1

### DIFF
--- a/.github/workflows/build-soda.yml
+++ b/.github/workflows/build-soda.yml
@@ -7,7 +7,7 @@ on:
 env:
   WINE_VERSION: 9.0
   BRANCH: experimental_9.0
-  REVISION: 0
+  REVISION: 1
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-soda.yml
+++ b/.github/workflows/build-soda.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:        
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: setup
         working-directory: /home/runner/work/
@@ -24,16 +24,14 @@ jobs:
           sudo apt install aptitude
           sudo aptitude remove -y '?narrow(?installed,?version(deb.sury.org))'
 
-      - name: clone wine-tkg-git repo
+      - name: clone wine-tkg-git repo and configure
         working-directory: /home/runner/work/
-        run: git clone https://github.com/Frogging-Family/wine-tkg-git.git
-
-      - name: get/set the soda recipe
-        working-directory: /home/runner/.config/frogminer/
         run: |
-          curl https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/wine-tkg-valve.cfg > wine-tkg.cfg
-          sed -i "s/_plain_version=\"\"/_plain_version=\"$BRANCH\"/g" wine-tkg.cfg
-
+          git clone https://github.com/Frogging-Family/wine-tkg-git.git
+          cd wine-tkg-git/wine-tkg-git
+          sed -i "s/_LOCAL_PRESET=\"\"/_LOCAL_PRESET=\"valve-exp-bleeding\"/g" customization.cfg
+          curl https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/wine-tkg-valve.cfg >> wine-tkg-profiles/wine-tkg-valve-exp-bleeding.cfg
+  
       - name: start build
         working-directory: /home/runner/work/wine-tkg-git/wine-tkg-git/
         run: yes|./non-makepkg-build.sh

--- a/.github/workflows/build-soda.yml
+++ b/.github/workflows/build-soda.yml
@@ -24,14 +24,17 @@ jobs:
           sudo apt install aptitude
           sudo aptitude remove -y '?narrow(?installed,?version(deb.sury.org))'
 
-      - name: clone wine-tkg-git repo and configure
+      - name: clone wine-tkg-git repo
         working-directory: /home/runner/work/
         run: |
           git clone https://github.com/Frogging-Family/wine-tkg-git.git
           cd wine-tkg-git/wine-tkg-git
           sed -i "s/_LOCAL_PRESET=\"\"/_LOCAL_PRESET=\"valve-exp-bleeding\"/g" customization.cfg
-          curl https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/wine-tkg-valve.cfg >> wine-tkg-profiles/wine-tkg-valve-exp-bleeding.cfg
-  
+
+      - name: get/set the soda recipe
+        working-directory: /home/runner/.config/frogminer/
+        run: curl https://raw.githubusercontent.com/bottlesdevs/build-tools/main/runners/vaniglia/wine-tkg-valve.cfg > wine-tkg.cfg
+      
       - name: start build
         working-directory: /home/runner/work/wine-tkg-git/wine-tkg-git/
         run: yes|./non-makepkg-build.sh

--- a/.github/workflows/build-soda.yml
+++ b/.github/workflows/build-soda.yml
@@ -7,7 +7,7 @@ on:
 env:
   WINE_VERSION: '9.0'
   BRANCH: experimental_9.0
-  REVISION: 1
+  REVISION: '1'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-soda.yml
+++ b/.github/workflows/build-soda.yml
@@ -5,7 +5,7 @@ on:
       - 'soda'
   workflow_dispatch:
 env:
-  WINE_VERSION: 9.0
+  WINE_VERSION: '9.0'
   BRANCH: experimental_9.0
   REVISION: 1
 jobs:


### PR DESCRIPTION
Note: This PR is dependent on this [PR](https://github.com/bottlesdevs/build-tools/pull/8) being committed first.

As per Etienne's [response](https://github.com/Frogging-Family/wine-tkg-git/issues/1161#issuecomment-2081299614) we basically have two options. Based on the new patch put out to fix the initial build issue and the quirks of the script, in order to get a bleeding edge build we would need to invoke the built in ```wine-tkg-valve-exp-bleeding.cfg``` config using ```_LOCAL_PRESET="valve-exp-bleeding"```. We could do this and only this but our build would be generic with no patches of our choosing. The second option is to do this and then append our desired options onto the existing ```wine-tkg-valve-exp-bleeding.cfg```, which should work but is basically a hack. 

For the sake of getting a working Soda 9.0 out I chose the second option, however before our next release I would like to review our patches and see if they still make sense. Several new patches and options exist including the new ```_wayland_driver``` flag which we should consider. Soda is now based on 9.0 but our patch choices have not kept up with the current state of WINE/Proton.

P.S. I have tested this build out locally. [Here](https://github.com/xioren/wine/releases/download/soda-9-0/soda-9-0-x86_64.tar.xz) is a release if you would also like to verify it.